### PR TITLE
Fix README typo and merging notion column suggest

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The tool can be run from the command line, e.g. to check the installed version o
 For example:
 
 ```Bash
->> a2b --arXiv https://arXiv.org/abs/1912.08957
+>> a2b --arxiv https://arXiv.org/abs/1912.08957
 
 ## __Optimization for deep learning: theory and algorithms.__ *Ruoyu Sun.* __ArXiv, 2019__ [(Arxiv)](ht
 ## tps://arXiv.org/abs/1912.08957) [(S2)](https://www.semanticscholar.org/paper/c23173e93f1db79a422e2af

--- a/README.md
+++ b/README.md
@@ -97,7 +97,6 @@ To generate bibliography from links saved in a Notion database, follow the instr
       * Author (rich_text)
       * Year (number)
       * Journal (rich_text)
-      * Arxiv (url)
       * Link (url)
       * S2 (url)
       * Citations (number)

--- a/a2b/notion.py
+++ b/a2b/notion.py
@@ -45,7 +45,7 @@ def generate_page_data(s2_id, title, author, journal, year, citations, arxiv_id=
         "S2": {"url": f"https://www.semanticscholar.org/paper/{s2_id}"}
     }
     if arxiv_id is not None:
-        metadata['Arxiv'] = {"url": f"https://arxiv.org/abs/{arxiv_id}"}
+        metadata['Link'] = {"url": f"https://arxiv.org/abs/{arxiv_id}"}
     if doi is not None:
         metadata['Link'] = {"url": f"https://doi.org/{doi}"}
     return {'properties': metadata}


### PR DESCRIPTION
- Fix the typo in the README command example
- Suggest merging `Link` and `Arxiv` two columns in notion DB to make it clear and readability

Thank you for developing this helpful tool, if you have any concerns about this PR please feel free to tell me.